### PR TITLE
Clarify if fiskaltrust is certified according to BSI TR-03153

### DIFF
--- a/qna/DE-fiskaltrust-certified.md
+++ b/qna/DE-fiskaltrust-certified.md
@@ -1,0 +1,15 @@
+## Question
+Is the fiskaltrust solution certified in germany?
+
+## Question
+Is fiskaltrust certified in germany?
+
+## Question
+Is fiskaltrust officially certified according to BSI TR-03153?
+
+## Metadata tags
+lang-en, market-de, middleware, PosCreator, PosDealer, Consultant
+
+## Answer
+
+Fiskaltrust is **NOT** a technical security unit (TSE). Fisklatrust offers a free of charge fiscalization middleware that is able to communicate with any officially certified TSE. Therefore fiskaltrust is not certified according to BSI TR-03153, but the supported TSEs such as Swissbit, Cryptovision, Diebold, Epson TSE are officially certified by the german Federal Office for Information Security (BSI).

--- a/qna/DE-fiskaltrust-certified.md
+++ b/qna/DE-fiskaltrust-certified.md
@@ -12,4 +12,4 @@ lang-en, market-de, middleware, PosCreator, PosDealer, Consultant
 
 ## Answer
 
-Fiskaltrust is **NOT** a technical security unit (TSE). Fisklatrust offers a free of charge fiscalization middleware that is able to communicate with any officially certified TSE. Therefore fiskaltrust is not certified according to BSI TR-03153, but the supported TSEs such as Swissbit, Cryptovision, Diebold, Epson TSE are officially certified by the german Federal Office for Information Security (BSI).
+Fiskaltrust is **NOT** a technical security unit (TSE). Fiskaltrust offers a free of charge fiscalization middleware that is able to communicate with any officially certified TSE. Therefore fiskaltrust is not certified according to BSI TR-03153, but the supported TSEs such as Swissbit, Cryptovision, Diebold, Epson TSE are officially certified by the german Federal Office for Information Security (BSI).


### PR DESCRIPTION
this qna explains that because fiskaltrust is not a TSE, it is not certified according to BSI TR-03153