### PR TITLE
Proper Noun Mistake (germany/Germany)

### DIFF
--- a/qna/DE-operating-systems.md
+++ b/qna/DE-operating-systems.md
@@ -1,18 +1,18 @@
 ## Question
-Which operating systems are supported in germany by fiskaltrust?
+Which operating systems are supported in Germany by fiskaltrust?
 
 ## Question
-Is Windows XP supported by fiskaltrust in germany?
+Is Windows XP supported by fiskaltrust in Germany?
 
 ## Question
-Is Android supported by fiskaltrust in germany?
+Is Android supported by fiskaltrust in Germany?
 
 ## Question
-Is Linux supported by fiskaltrust in germany?
+Is Linux supported by fiskaltrust in Germany?
 
 ## Question
 
-Is iOS (iPad/iPhone Devices) supported by fiskaltrust in germany?
+Is iOS (iPad/iPhone Devices) supported by fiskaltrust in Germany?
 
 ## Question
 
@@ -23,7 +23,7 @@ lang-en, market-de, middleware, PosCreator, PosDealer, Consultant
 
 ## Answer
 
-Please find the list of supported operating systems for germany in our fiskaltrust.Middleware [product description in german language](https://github.com/fiskaltrust/productdescription-de-doc/blob/master/product-service-description/compliance-as-a-service/produkte/4445-0003-lokal-installierte-middleware.md).
+Please find the list of supported operating systems for Germany in our fiskaltrust.Middleware [product description in german language](https://github.com/fiskaltrust/productdescription-de-doc/blob/master/product-service-description/compliance-as-a-service/produkte/4445-0003-lokal-installierte-middleware.md).
 
 If your platform is not supported natively by our middleware right now, solutions can be still found considering different architectural scenarios described in the [product documentation](https://github.com/fiskaltrust/productdescription-de-doc/blob/master/for-posdealers/03-sales/rollout-scenarios.md).
 


### PR DESCRIPTION
The word "germany" is a proper noun